### PR TITLE
Update to bevy 0.13 and serde 1.0.197; bump version to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_utilitarian"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -11,8 +11,8 @@ keywords = ["bevy", "gamedev", "utility", "interpolation", "math"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0.196", features = ["derive"] }
-bevy = { version = "0.12.0", default-features = false, features = [
+serde = { version = "1.0.197", features = ["derive"] }
+bevy = { version = "0.13", default-features = false, features = [
     "bevy_render",
 ] }
 rand = "0.8.5"

--- a/src/curves/color_point.rs
+++ b/src/curves/color_point.rs
@@ -78,7 +78,7 @@ impl Sum for ColorPoint {
         let mut c = Color::BLACK;
 
         for i in iter {
-            c += i.color;
+            c = c + i.color;
         }
 
         Self { color: c }


### PR DESCRIPTION
I updated the crate for bevy 0.13